### PR TITLE
Fix: Update authentication and add NodeJS examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ const client = new HellioMessaging({
 });
 
 // Send an SMS
-const smsParams = {
+const smsParamsOld = {
     senderId: "yourSenderId",
     msisdn: "recipientPhoneNumber",
     message: "Hello, World!",
 };
 
 client
-    .sendSMS(smsParams)
+    .sendSMS(smsParamsOld)
     .then((response) => {
         console.log("SMS sent successfully:", response);
     })
@@ -50,7 +50,7 @@ client
     });
 
 // Generate OTP
-const otpParams = {
+const otpParamsOld = {
     mobile_number: "recipientPhoneNumber",
     timeout: 60,
     message: "Your verification code is: {OTP}",
@@ -61,7 +61,7 @@ const otpParams = {
 };
 
 client
-    .sendOTP(otpParams)
+    .sendOTP(otpParamsOld)
     .then((response) => {
         console.log("OTP sent successfully:", response);
     })
@@ -70,13 +70,13 @@ client
     });
 
 // Verify OTP
-const verifyParams = {
+const verifyParamsOld = {
     mobile_number: "recipientPhoneNumber",
     otp: "otpCode",
 };
 
 client
-    .verifyOTP(verifyParams)
+    .verifyOTP(verifyParamsOld)
     .then((response) => {
         console.log("OTP verification successful:", response);
     })
@@ -145,6 +145,78 @@ client
 
 ```
 
+### More Examples:
+
+```javascript
+const HellioMessaging = require('helliomessaging'); // Assuming the package name is 'helliomessaging'
+
+// Initialize with your credentials
+const hellioOptions = {
+    clientId: 'YOUR-CLIENT-ID',
+    applicationSecret: 'YOUR-CLIENT-SECRET'
+};
+
+const hellioMessaging = new HellioMessaging(hellioOptions);
+
+// Define SMS parameters
+const smsParams = {
+    senderId: 'YourSenderID', // Max 11 characters
+    msisdn: '233242813656', // Recipient's mobile number
+    message: 'Hello from HellioMessaging NodeJS SDK!'
+};
+
+// Send SMS
+hellioMessaging.sendSMS(smsParams)
+    .then(response => {
+        console.log('SMS sent successfully!');
+        console.log('Response:', response);
+        // Expected successful response structure:
+        // { success: true, messageId: "some-message-id", ... }
+    })
+    .catch(error => {
+        console.error('Error sending SMS:');
+        console.error('Error details:', error);
+        // Expected error response structure:
+        // { success: false, error: "Error message", ... }
+    });
+
+// Example for sending OTP (already in the library)
+const otpParams = {
+    mobile_number: "233242813656",
+    // timeout: 600, // Optional: defaults to 600 seconds
+    // message: "Your OTP is {otp_code}", // Optional: Customize message
+    senderId: "YourSenderID",
+    // tokenlength: 6, // Optional: defaults to 6
+    // recipient_email: "user@example.com", // Optional
+    // messageType: 0 // Optional: 0 for text, 1 for voice; defaults to 0
+};
+
+hellioMessaging.sendOTP(otpParams)
+    .then(response => {
+        console.log('OTP sent successfully!');
+        console.log('Response:', response);
+    })
+    .catch(error => {
+        console.error('Error sending OTP:');
+        console.error('Error details:', error);
+    });
+
+// Example for Verifying OTP (already in the library)
+const verifyOtpParams = {
+    mobile_number: "233242813656",
+    otp: "123456" // The OTP code received by the user
+};
+
+hellioMessaging.verifyOTP(verifyOtpParams)
+    .then(response => {
+        console.log('OTP verified successfully!');
+        console.log('Response:', response);
+    })
+    .catch(error => {
+        console.error('Error verifying OTP:');
+        console.error('Error details:', error);
+    });
+```
 
 ## Features
 

--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -12,32 +12,62 @@ describe("HellioMessaging", () => {
 
     // Send SMS
     describe("sendSMS", () => {
+        let mockPost;
+
+        beforeEach(() => {
+            // Reset the mock before each test
+            mockPost = jest.spyOn(hellioMessaging.api, 'post');
+        });
+
+        afterEach(() => {
+            // Restore the original implementation after each test
+            mockPost.mockRestore();
+        });
+
         it("should send an SMS message successfully", async () => {
             // Define test parameters
-            const senderId = "HellioSMS";
-            const msisdn = "233242813656";
-            const message = "Hello, this is a test message from the Hellio Messaging NodeJs package.";
+            const params = {
+                senderId: "HellioSMS",
+                msisdn: "233242813656",
+                message: "Hello, this is a test message from the Hellio Messaging NodeJs package.",
+            };
+
+            // Mock the successful API response
+            mockPost.mockResolvedValueOnce({
+                // data is not nested under a data property in the original code when returning response.data
+                success: true,
+                messageId: "some-message-id",
+            });
 
             // Call the sendSMS function
-            const result = await hellioMessaging.sendSMS(senderId, msisdn, message);
+            const result = await hellioMessaging.sendSMS(params);
 
             // Assert that the result is successful
             expect(result.success).toBe(true);
-            expect(result.messageId).toBeDefined();
+            expect(result.messageId).toBe("some-message-id");
         });
 
         it("should return an error for invalid parameters", async () => {
             // Define test parameters with invalid values
-            const senderId = "";
-            const msisdn = "INVALID_PHONE_NUMBER";
-            const message = "";
+            const params = {
+                senderId: "",
+                msisdn: "INVALID_PHONE_NUMBER",
+                message: "",
+            };
+
+            // Mock the error API response
+            // The original code uses Promise.reject(error.response.data)
+            mockPost.mockRejectedValueOnce({
+                success: false,
+                error: "Invalid parameters",
+            });
 
             // Call the sendSMS function
-            const result = await hellioMessaging.sendSMS(senderId, msisdn, message);
+            const result = await hellioMessaging.sendSMS(params);
 
             // Assert that the result contains an error
             expect(result.success).toBe(false);
-            expect(result.error).toBeDefined();
+            expect(result.error).toBe("Invalid parameters");
         });
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,6 @@ class HellioMessaging {
             baseURL: this.baseURL,
             headers: {
                 "Content-Type": "application/json",
-                Authorization: `Bearer ${this.getAuthToken()}`,
             },
         });
     }
@@ -30,6 +29,8 @@ class HellioMessaging {
         const endpoint = "/v2/sms";
 
         const payload = {
+            clientId: this.clientId,
+            authKey: this.getAuthToken(),
             senderId: params.senderId,
             msisdn: params.msisdn,
             message: params.message,


### PR DESCRIPTION
- Updated `src/index.js`:
    - Removed Authorization header from axios instance.
    - Added `clientId` and `authKey` to the `sendSMS` payload to align with API documentation.
- Updated `__test__/index.test.js`:
    - Modified `sendSMS` tests to pass parameters as an object.
    - Mocked API responses for `sendSMS` tests to ensure reliability and avoid actual API calls during testing.
- Updated `README.md`:
    - Added a new NodeJS code sample for `sendSMS`.
    - Included examples for `sendOTP` and `verifyOTP` for completeness under a new "More Examples" subsection.
    - Ensured the README is well-formatted.